### PR TITLE
Cli default param fix

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,7 +20,7 @@ program
   .description('Train your mine locally using a sonar smart contract')
   .option('-m, --mine-address <hexstring>', 'Blockchain address for the mine to use')
   .option('-c, --contract-address <hexstring>', 'Sonar smart contract address for the mine to use')
-  .option('-i, --ipfs-url [url]', 'Url of the IPFS node (Default: "http://localhost:5001")')
+  .option('-i, --ipfs-url [url]', 'Url of the IPFS node (Default: "/ip4/127.0.0.1/tcp/5001")')
   .option('-e, --ethereum-url [url]', 'Url to the ethereum network to use (Default: "http://localhost:8545")')
   // TODO: Add dev mode with watching
   .action((options) => {
@@ -32,7 +32,7 @@ program
     if (!contractAddress) return console.log('--contract-address required')
 
     const ethereumUrl = options.ethereumUrl || 'http://localhost:8545'
-    const ipfsUrl = options.ipfsUrl || 'http://localhost:5001'
+    const ipfsUrl = options.ipfsUrl || '/ip4/127.0.0.1/tcp/5001'
     app.checkForModels(mineAddress, contractAddress, ethereumUrl, ipfsUrl)
   })
 

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -10,9 +10,6 @@ services:
      - ../data/ipfs/data:/data/ipfs
      - ../data/ipfs/staging:/export
   testrpc:
-    build:
-      context: ../../Sonar
-      dockerfile: Dockerfile.testrpc
-    # image: "openmined/sonar-testrpc:edge"
+    image: "openmined/sonar-testrpc:edge"
     ports:
       - "8545:8545"

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -10,6 +10,9 @@ services:
      - ../data/ipfs/data:/data/ipfs
      - ../data/ipfs/staging:/export
   testrpc:
-    image: "openmined/sonar-testrpc:edge"
+    build:
+      context: ../../Sonar
+      dockerfile: Dockerfile.testrpc
+    # image: "openmined/sonar-testrpc:edge"
     ports:
       - "8545:8545"


### PR DESCRIPTION
Updates `ipfsUrl` to use a multiaddr (see https://github.com/multiformats/multiaddr)  instead of  a URI. 