### PR TITLE
build docker container with new cli interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . /app
 # Create app directory
 WORKDIR /app
 
-CMD [ "node", "app" ]
+CMD [ "node", "bin/cli", "train", "--mine-address", "0xE8cd631a35daEA6c76cF9a8c04C1a326fE69f9A9", "--contract-address", "0xdde11dad6a87e03818aea3fde7b790b644353ccc" ]


### PR DESCRIPTION
Use default addresses that work with the `openmined/sonar-testrpc` image until #31 is implemented